### PR TITLE
Fix the incorrect message name in messages.proto

### DIFF
--- a/grpc/method.go
+++ b/grpc/method.go
@@ -56,7 +56,7 @@ func ParseMethod(m abi.Method) (Method, []Message) {
 		requiredMessages = append(requiredMessages, ToMessage(method.RequestName(), method.Inputs))
 	}
 	if len(method.Outputs) > 0 {
-		requiredMessages = append(requiredMessages, ToMessage(method.RequestName(), method.Outputs))
+		requiredMessages = append(requiredMessages, ToMessage(method.ResponseName(), method.Outputs))
 	}
 
 	return method, requiredMessages


### PR DESCRIPTION
While generate the messages.proto , the message name of the return value for smart contract's constant function is incorrect.
For example , 
if a smart contract has a `getName` function which return a string ,
it will generate an unexpected `GetNameReq` message instead of generating `GetNameResp` message in the messages.proto.